### PR TITLE
Only add 'blocked' note after block popup confirmation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/klntsky/x-user-note/issues/5
-Your prepared branch: issue-5-b905dc478943
-Your prepared working directory: /tmp/gh-issue-solver-1766657718813
-Your forked repository: konard/klntsky-x-user-note
-Original repository (upstream): klntsky/x-user-note
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/klntsky/x-user-note/issues/5
+Your prepared branch: issue-5-b905dc478943
+Your prepared working directory: /tmp/gh-issue-solver-1766657718813
+Your forked repository: konard/klntsky-x-user-note
+Original repository (upstream): klntsky/x-user-note
+
+Proceed.


### PR DESCRIPTION
## Summary

Fixes #5

This PR changes the extension behavior so that the 'Blocked' note is only saved **after** the user confirms the block action in X/Twitter's confirmation dialog, not immediately when clicking the Block menu item.

### Changes

- Added `waitForBlockConfirmation()` function that uses a MutationObserver to detect when the block confirmation dialog appears
- Modified `handleMuteBlockButtonClick()` to differentiate between Mute and Block actions:
  - **Mute actions**: Save note immediately (no confirmation dialog in X)
  - **Block actions**: Wait for user to click the confirmation button (`data-testid="confirmationSheetConfirm"`) before saving
- Observer automatically disconnects after 10 seconds or when the confirmation button is found

### Why This Matters

Previously, if a user clicked "Block" but then cancelled in the confirmation dialog, the extension would still save a "Blocked" note for that user. Now the note is only saved when the block actually happens.

## Test Plan

- [ ] Click "Block @username" from a tweet menu, then **cancel** the confirmation dialog → No note should be saved
- [ ] Click "Block @username" from a tweet menu, then **confirm** the block → "Blocked on [timestamp]" note should be saved
- [ ] Click "Mute @username" from a tweet menu → "Muted on [timestamp]" note should be saved immediately (no change from previous behavior)
- [ ] Verify notes sync correctly between hover cards and profile pages after blocking
- [ ] Verify the extension works on both tweet menus and profile page menus

🤖 Generated with [Claude Code](https://claude.com/claude-code)